### PR TITLE
Support for Register screen

### DIFF
--- a/src/Components/LoginScreen.js
+++ b/src/Components/LoginScreen.js
@@ -2,10 +2,18 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Text, View, TouchableOpacity, StyleSheet } from "react-native";
 import { login } from "../Actions/actionCreator";
+import { NavigationActions } from "react-navigation";
 
 class LoginScreen extends Component {
   static navigationOptions = {
     title: "Login"
+  };
+  navigate = () => {
+    const navigateToRegister = NavigationActions.navigate({
+      routeName: "screen1"
+
+    });
+    this.props.navigation.dispatch(navigateToRegister);
   };
   render() {
     return (
@@ -26,6 +34,12 @@ class LoginScreen extends Component {
           style={styles.touchableStyles}
         >
           <Text style={{ color: "white", fontSize: 22 }}>Login</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={this.navigate}
+          style={styles.touchableStyles}
+        >
+          <Text style={{ color: "white", fontSize: 22 }}>Register</Text>
         </TouchableOpacity>
       </View>
     );

--- a/src/Components/screen2.js
+++ b/src/Components/screen2.js
@@ -17,7 +17,7 @@ class LogoutScreen extends Component {
           alignItems: "center"
         }}
       >
-        <Text>{this.props.navigation.state.params.name}</Text>
+        <Text>{'Test'}</Text>
         <TouchableOpacity
           onPress={this.props.logout}
           style={styles.touchableStyles}

--- a/src/Navigation/navigationStack.js
+++ b/src/Navigation/navigationStack.js
@@ -27,4 +27,5 @@ const navigator = StackNavigator({
   }
 });
 
+export {Tabs}
 export default navigator;

--- a/src/Reducers/navigationReducer.js
+++ b/src/Reducers/navigationReducer.js
@@ -1,21 +1,21 @@
 import { NavigationActions } from "react-navigation";
 
-import AppNavigator from "../Navigation/navigationStack";
+import AppNavigator, {Tabs} from "../Navigation/navigationStack";
 import { Login, Logout } from "../Actions/actionTypes";
 
 const ActionForLoggedOut = AppNavigator.router.getActionForPathAndParams(
   "login"
 );
 
-const ActionForLoggedIn = AppNavigator.router.getActionForPathAndParams(
-  "screen1"
+const ActionForLoggedIn = Tabs.router.getActionForPathAndParams(
+  "feed"
 );
 
 const stateForLoggedOut = AppNavigator.router.getStateForAction(
   ActionForLoggedOut
 );
 
-const stateForLoggedIn = AppNavigator.router.getStateForAction(
+const stateForLoggedIn = Tabs.router.getStateForAction(
   ActionForLoggedIn
 );
 
@@ -52,10 +52,10 @@ const navigationReducer = (state = initialState, action) => {
         )
       };
 
-    /* Other logic for logging out, more cleaner but unlike the above isn't telling the reader 
+    /* Other logic for logging out, more cleaner but unlike the above isn't telling the reader
            that navigation is reset, that's why I chose the *reset* one for the article. I prefer
            this one, what about you?
-        
+
         case 'LOGOUT':
             nextState = { ...state, initialStateForLoggedIn, initialStateForLoggedOut}
             break;


### PR DESCRIPTION
Hey @shubhnik 
Just wanted to share the diff of what I am trying to build on top of the nestedTab branch. 
I will move this to separate branch, once we decide on how to go about to support this scenario.

So basically trying to add a `Register` button on the login screen, which will navigate to the `screen` in the `StackNavigator`.
But for that to work, seems i need to define it as an action and state as well. And have another redux state to handle the register action.

So I am thinking if thats the route we go with, I would then need to define all these actions and state before hand for : `login` `register` `password forget` .
Is that how this will work ?